### PR TITLE
[update] Client: allow multiple instances by not extending DEFAULT co…

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,8 +121,8 @@
 
     var Client = exports.Client = function(options){
 
-        var client     = this;
-        var _jar        = request.jar();
+        var client  = this;
+        var _jar    = request.jar();
 
         options = options || {};
 
@@ -156,9 +156,9 @@
             }
         }
 
-        var ctx        = extend(DEFAULTS, options);
-        var _request   = request.defaults(ctx);
-        var requestStyle     = (options.enqueue) ? 'async' : 'request';
+        var ctx             = extend({}, DEFAULTS, options);
+        var _request        = request.defaults(ctx);
+        var requestStyle    = (options.enqueue) ? 'async' : 'request';
 
         //internal request queue
         var requestQueue = async.queue(function work(requestCtx, responseHandler) {


### PR DESCRIPTION
[update] Client: allow multiple instances by not extending DEFAULT configs with most recent options

use case: migrating data from one environment to another needs a second instance of the rest client

cause: extending `DEFAULTS` variable outside of the constructor's scope overwrites an instance's default configs, thus causing requests to point to the last instantiated configurations
